### PR TITLE
Clarify cryptographic magic numbers

### DIFF
--- a/src/crypto.c
+++ b/src/crypto.c
@@ -182,9 +182,24 @@ zxerr_t crypto_sign(const hd_path_t path,
                                sizeof(messageDigest),
                                &messageDigestSize));
 
-    if (messageDigestSize != CURVE_ORDER_SIZE) {
+
+    // check the message worked properly
+    if (cx_hash_kind == HASH_SHA2_256 && messageDigestSize != CX_SHA256_SIZE) {
         zemu_log_stack("crypto_sign: zxerr_out_of_bounds");
         return zxerr_out_of_bounds;
+    }
+
+    if (cx_hash_kind == HASH_SHA3_256 && messageDigestSize != CX_SHA3_256_SIZE) {
+        zemu_log_stack("crypto_sign: zxerr_out_of_bounds");
+        return zxerr_out_of_bounds;
+    }
+
+    // check that the hashing choice doesn't reduce the curve security.
+    // it's enough to check that the digest size is larger or equal to the group order
+    // but we check the equality to make sure the algos are fully compatible.
+    if (messageDigestSize != CURVE_ORDER_SIZE) {
+        zemu_log_stack("crypto_sign: zxerr_invalid_crypto_settings");
+        return zxerr_invalid_crypto_settings;
     }
 
     size_t signatureLength;

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -88,9 +88,6 @@ typedef struct {
     uint8_t r[32];
     uint8_t s[32];
     uint8_t v;
-
-    // DER signature max size should be 73
-    // https://bitcoin.stackexchange.com/questions/77191/what-is-the-maximum-size-of-a-der-encoded-ecdsa-signature#77192
     uint8_t der_signature[73];
 } __attribute__((packed)) signature_t;
 

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -32,7 +32,18 @@ typedef enum { CURVE_UNKNOWN, CURVE_SECP256K1, CURVE_SECP256R1 } curve_e;
 
 #if defined(TARGET_NANOS) || defined(TARGET_NANOX) || defined(TARGET_NANOS2)
 #else
+/* output sizes of the supported hash algorithms */
 #define CX_SHA256_SIZE 32
+#define CX_SHA3_256_SIZE 32
+
+/* constants related to the supported elliptic curves */
+/* the currently supported curves have the same group order byte size and prime field byte size */
+#define CURVE_ORDER_SIZE 32
+#define CURVE_FIELD_SIZE 32
+#define PUB_KEY_SIZE ((2*CURVE_FIELD_SIZE)+1)
+// DER signature max size should be 73
+// https://bitcoin.stackexchange.com/questions/77191/what-is-the-maximum-size-of-a-der-encoded-ecdsa-signature#77192
+#define DER_SIG_MAX_SIZE (2*(CURVE_ORDER_SIZE+3)+3)
 #endif
 
 void sha256(const uint8_t *message, uint16_t messageLen, uint8_t message_digest[CX_SHA256_SIZE]);


### PR DESCRIPTION
- declare new cryptographic constants related to sha3 and the supported elliptic curves. 
- use the cryptographic constants to replace magic numbers

The purpose is: 
 - clarify the intention of using magic numbers (especially when the same constant `32` is used multiple times, but it has a different meaning depending on the context)
 - make the code base more robust if more hashing algorithms or elliptic curves are used in the future